### PR TITLE
add pages to publishing pool

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,7 @@
+---
+share: true
+---
+
 # Contributing to the Vault
 
 So you want to lend your hand at making the Vault just a little bit better. Great! ...Where do you start? It depends on how you want to help. If you just want give us suggestions of pages to add or let us know about typos you notice, head over to [[Using GitHub#Issues|Issues]]. If you want to do something yourself, read on. 

--- a/Using Git.md
+++ b/Using Git.md
@@ -1,3 +1,7 @@
+---
+share: true
+---
+
 # Using Git
 
 Git can feel a little intimidating to learn, but it's not actually that complicated (I know that's what everyone says and it's not always true but I promise you can handle it). 

--- a/Using GitHub.md
+++ b/Using GitHub.md
@@ -1,3 +1,7 @@
+---
+share: true
+---
+
 # Using GitHub
 GitHub is a place to keep [[Using Git|Git]] repositories - it's usually used for code, really can be useful with any project made up of mainly text files. Good news for us, that describes our Vault perfectly!
 

--- a/Using Obsidian.md
+++ b/Using Obsidian.md
@@ -1,3 +1,7 @@
+---
+share: true
+---
+
 # Using Obsidian
 ## Quick Start Guide
 If you just want to start browsing the Vault in Obsidian.


### PR DESCRIPTION
adds `share: true` to the frontmatter of 4 pages, for publishing. It should have been done before merging #9, but it was just about the only thing I didn't think of before merging, and it only occurred to me when I went to hit publish.